### PR TITLE
Fix TS definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare function cleanDeep<T>(object: T, options?: CleanOptions): Partial<T>;
 
-export default cleanDeep;
+export = cleanDeep;
 
 export type CleanOptions = {
     cleanKeys?: string[];


### PR DESCRIPTION
The source code uses `module.exports = ...`, not `exports.default = ...`:

https://github.com/nunofgs/clean-deep/blob/9d8313db868b239b990f9db352215844ad7ae65a/src/index.js#L14-L22

Given this, TS definitions should use `export =`, not `export default`. See https://github.com/microsoft/TypeScript/issues/7185#issuecomment-354566288.

This matters when the project is compiled _without_ the `"esModuleInterop": true` flag. In that case, doing

```ts
import cleanDeep from 'clean-deep'

cleanDeep(...)
```

would throw an error like `TypeError: clean_deep_1.default is not a function`.